### PR TITLE
YAML Formatting Fix hue_dimmer_zha.yaml

### DIFF
--- a/blueprints/automations/inovelli/hue_dimmer_zha.yaml
+++ b/blueprints/automations/inovelli/hue_dimmer_zha.yaml
@@ -4,6 +4,7 @@ blueprint:
 description: >
   🎯 All-in-one automation for Inovelli Blue switches (ZHA) and Hue Rooms/Zones
 
+<details>
   ✅ Paddle tap → On/Off  
   ✅ Paddle hold/release → Smooth dimming  
   ✅ Side button (button 3) → Cycle Hue scenes (forward/backward)  
@@ -12,7 +13,7 @@ description: >
   ✅ Configurable brightness step (percent)  
   ✅ Double-tap up → Set light to 100% brightness  
   ✅ Double-tap down → Set light to 10% brightness
-
+<details>
 
   domain: automation
 


### PR DESCRIPTION
attempting to add blueprint in HA triggers the following error:

"Invalid blueprint: required key not provided @ data['blueprint']['domain']. Got None"

 blueprint is broken due to formatting under 'description'. Fix can be had by adding <details> under description or fixing tab formatting of (at least) line 7.